### PR TITLE
Add Header Title to Anchor Class

### DIFF
--- a/build/jqm.editable.listview.js
+++ b/build/jqm.editable.listview.js
@@ -97,6 +97,10 @@
                 ui.header = ui.wrapper.find('.ui-collapsible-heading')
                 ui.button = ui.header.find('a a, a button')
                 ui.content = ui.wrapper.find('.ui-collapsible-content')
+
+				// add anchor so I can attach identifying class
+				ui.anchor = ui.header.find('.ui-collapsible-heading-toggle');
+				
                 ui.form = this._getForm();
                 
                 $.extend(this, {
@@ -316,7 +320,10 @@
                 .children("a")[0]
                 .childNodes[0]
                 .data = (isListEmpty) ? opts.emptyTitle : opts.title;
-
+				
+			// attached header title as class to enable custom styling to added later
+			ui.anchor.addClass(opts.title.replace(/\s+/g, ''));
+			
             // changing "Edit" button state, icon and label
             ui.button.removeClass('ui-icon-minus ui-icon-' + opts.doneIcon + ' ui-icon-' + opts.addIcon + ' ui-icon-' + opts.editIcon)
                 .addClass('ui-icon-' + (this._editMode ? opts.doneIcon : isListEmpty ? opts.addIcon : opts.editIcon))

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -1,0 +1,3 @@
+.Fruits {
+	background-color:#F29968 !important;
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,9 +15,9 @@
 	<script src="http://code.jquery.com/jquery-2.1.1.js"></script>
 	<script src="http://ajax.googleapis.com/ajax/libs/jquerymobile/1.4.2/jquery.mobile.js"></script>
 <!--	<script src="../../jquery-mobile/dist/jquery.mobile.js"></script>-->
-<!--	<script src="../build/jqm.editable.listview.js"></script>-->
+	<script src="../build/jqm.editable.listview.js"></script>-->
 	<script src="../js/collapsible-patched.js"></script>
-	<script src="../js/editable-listview.js"></script>
+<!--	<script src="../js/editable-listview.js"></script>-->
 </head>
 
 <body style="padding: 20px">
@@ -44,7 +44,7 @@
         <br>
 
         <p>Delete <strong>"Orange"</strong> from the following list of <strong>"Fruits"</strong></p>
-        <ul id="list3" data-role="listview" data-editable="true" data-editable-type="simple" data-title="Fruits" data-empty-title="No Fruits">
+        <ul id="list3" data-role="listview" data-editable="true" data-editable-type="simple" data-title="Sweet Fruits" data-empty-title="No Fruits">
             <li>Apple</li>
             <li>Orange</li>
             <li>Banana</li>


### PR DESCRIPTION
Hello.  I love the functionality of the Editable Listview and look forward to further enhancements.  I had a case where I had multiple listview instances on a single webpage and wanted to be able to make the headings different colors.  I tested applying styling to different tags and it seemed that the proper place to apply styling was to a dynamically generated anchor tag that you can see in Firebug when the page is fully rendered.

Therefore, I entered some simple code that removes any spaces from the header title text (data-title) and adds it as a class to the afore mentioned anchor tag.  I updated demo/index.html and demo.css to demonstrate this enhancement.

Thanks again for your hard work in creating the JQM editable Listview.
David